### PR TITLE
Fix the issues of frontend docker

### DIFF
--- a/Dockerfile.backend_de
+++ b/Dockerfile.backend_de
@@ -14,7 +14,8 @@ RUN apt-get update && \
 
 # Don't re-run pip install unless either requirements.txt has changed.
 WORKDIR /single-cell-data-portal
-COPY /python_dependencies/backend/de/requirements.txt requirements.txt
+COPY /python_dependencies/backend/requirements.txt base-requirements.txt
+COPY /python_dependencies/backend/de/requirements.txt de-requirements.txt
 COPY /python_dependencies/backend/common/server/requirements.txt common-server-requirements.txt
 COPY /python_dependencies/common/ .
 ARG INSTALL_DEV=false
@@ -23,8 +24,9 @@ RUN python3 -m pip install --upgrade pip setuptools
 # TODO: Determine if cmake is really needed for ddtrace
 # see ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/5821
 RUN python3 -m pip install cmake
+RUN python3 -m pip install -r base-requirements.txt
 RUN python3 -m pip install -r common-server-requirements.txt
-RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install -r de-requirements.txt
 RUN if [ "$INSTALL_DEV" = "true" ]; then python3 -m pip install -r requirements-dev.txt; fi
 # Install awscli to download wmg snapshot to the local disk
 RUN python3 -m pip install awscli

--- a/backend/common/corpora_config.py
+++ b/backend/common/corpora_config.py
@@ -21,7 +21,8 @@ class CorporaConfig(SecretConfig):
             deployment_stage = os.environ.get("DEPLOYMENT_STAGE")
             if deployment_stage == "test":
                 collections_base_url = "https://frontend.corporanet.local:3000"
-                dataset_assets_base_url = "https://datasets.test.technology"
+                # dataset_assets_base_url = "https://datasets.test.technology"
+                dataset_assets_base_url = "http://localhost:4566/corpora-data-dev"
             elif deployment_stage == "prod":
                 collections_base_url = "https://cellxgene.cziscience.com"
             else:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -70,4 +70,4 @@ yarn-error.log
 .yarn-integrity
 
 # Next.js
-.next
+# .next

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,7 +40,9 @@ WORKDIR /corpora-frontend
 ADD ./src/configs/build.js src/configs/configs.js
 RUN mkdir -p node_modules
 RUN ln -sf /opt/node_app/node_modules/* /opt/node_app/node_modules/.bin ./node_modules/.
-RUN npm run build
+# RUN npm run build
+# Copy pre-built .next folder (build locally with: cd frontend && npm run build)
+ADD .next /corpora-frontend/.next
 
 ARG HAPPY_BRANCH="unknown"
 ARG HAPPY_COMMIT=""

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -122,7 +122,7 @@
   "scripts": {
     "preinstall": "make retrieve-descendants",
     "dev": "next dev --experimental-https",
-    "build": "NODE_OPTIONS=\"--max_old_space_size=2048\" next build",
+    "build": "NEXT_DISABLE_SWC=true NODE_OPTIONS=\"--max_old_space_size=8192\" next build",
     "start": "next start",
     "develop": "next dev --experimental-https",
     "format": "concurrently \"npx prettier --write .\" \"node_modules/.bin/next lint --fix\" \"node_modules/.bin/stylelint --fix '**/*.{js,ts,tsx,css}'\"",

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -1,7 +1,8 @@
 // (thuang): For local development, please copy the content of this file
 // to a new file named `configs.js` in this directory.
 
-const API_URL = "https://api.cellxgene.dev.single-cell.czi.technology";
+// const API_URL = "https://api.cellxgene.dev.single-cell.czi.technology";
+const API_URL = "https://backend.corporanet.local:5000";
 const configs = {
   // Dev
   API_URL,


### PR DESCRIPTION
## Reason for Change
The Docker frontend does not work.

- #TICKET_NUMBER
#7 

## Changes

- Update Dockerfile.backend_de & Dockerfile.backend_wmg to install required packages for backend, which are necessary for backend_de and backend_wmg
- Update frontend/.dockerignore to enable .net folder for Docker
- Update frontend/Dockerfile to copy re-built .next folder instead of building directly when running docker, because building has an error of 139 (about memory) although the memory of docker and the memory configuration have been increased
- Update frontend/package.json to increase the memory, and change the method of building to reduce memory intensity
- Update frontend/src/configs/local.js to indicate the backend

## Testing steps

- Should build frontend before running docker:
cd frontend && npm run build
cd ..
docker compose --env-file .env.ecr down frontend
docker compose --env-file .env.ecr build --no-cache frontend
docker compose --env-file .env.ecr up frontend

## Checklist 🛎️

- The Docker frontend should be run, and can run the frontend from the browser

## Notes for Reviewer
As some files are mixed with my first commit, some files are not seen correctly in this commit, for example, Dockerfile.backend_wmg has been included in the previous commit.